### PR TITLE
SVG support for placeholder image

### DIFF
--- a/Configuration/FlexForms/Script.xml
+++ b/Configuration/FlexForms/Script.xml
@@ -61,7 +61,7 @@
                     <config>
                         <appearance>
                             <elementBrowserType>file</elementBrowserType>
-                            <elementBrowserAllowed>jpg,png</elementBrowserAllowed>
+                            <elementBrowserAllowed>jpg,png,svg</elementBrowserAllowed>
                         </appearance>
                     </config>
                 </foreign_selector_fieldTcaOverride>


### PR DESCRIPTION
There is no reason, why it should not be possible to use a SVG file as placeholder image