### PR TITLE
Fixed Flexform SheetTitle

### DIFF
--- a/Configuration/FlexForms/Cookie.xml
+++ b/Configuration/FlexForms/Cookie.xml
@@ -4,7 +4,7 @@
         <sDEF>
             <ROOT>
                 <TCEforms>
-                    <sheetTitle>LLL:EXT:extkey/Resources/Private/Language/Backend.xlf:settings.registration.title</sheetTitle>
+                    <sheetTitle>LLL:EXT:wacon_cookie_management/Resources/Private/Language/Backend.xlf:settings.registration.title</sheetTitle>
                 </TCEforms>
                 <type>array</type>
                 <el>

--- a/Configuration/FlexForms/Script.xml
+++ b/Configuration/FlexForms/Script.xml
@@ -4,7 +4,7 @@
         <sDEF>
             <ROOT>
                 <TCEforms>
-                    <sheetTitle>LLL:EXT:extkey/Resources/Private/Language/Backend.xlf:settings.registration.title</sheetTitle>
+                    <sheetTitle>LLL:EXT:wacon_cookie_management/Resources/Private/Language/Backend.xlf:settings.registration.title</sheetTitle>
                 </TCEforms>
                 <type>array</type>
                 <el>

--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -38,6 +38,9 @@
             <trans-unit id="settings.cookiefreigabe.dataprotection">
                 <source>Privacy source url</source>
             </trans-unit>
+            <trans-unit id="settings.registration.title">
+                <source>Settings</source>
+            </trans-unit>
 
    </body>
     </file>

--- a/Resources/Private/Language/de.Backend.xlf
+++ b/Resources/Private/Language/de.Backend.xlf
@@ -38,7 +38,9 @@
             <trans-unit id="settings.cookiefreigabe.dataprotection">
                 <target>Link zur Datenschutzerklärung</target>
             </trans-unit>
-
+            <trans-unit id="settings.registration.title">
+                <target>Einstellungen</target>
+            </trans-unit>
 
    </body>
     </file>


### PR DESCRIPTION
There was a wrong reference to translations of sheet titles for the flexforms.
Fixed the reference and added translations.
