### PR TITLE
removed unused $resFactory

### DIFF
--- a/Classes/ViewHelpers/FALViewHelper.php
+++ b/Classes/ViewHelpers/FALViewHelper.php
@@ -18,7 +18,6 @@ class FALViewHelper extends AbstractViewHelper
     }
     public static function renderStatic( array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        $resFactory = \TYPO3\CMS\Core\Resource\ResourceFactory::getInstance();
         $table = $arguments['table'] != NULL ? $arguments['table'] : 'tt_content';
         $field = $arguments['field'];
         $uid = intval($arguments['uid']);


### PR DESCRIPTION
removed deprecated but unused call of ResourceFactory::getInstance() which throws "Call to undefined method TYPO3\CMS\Core\Resource\ResourceFactory::getInstance()" in TYPO3 11

(see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.3/Deprecation-90260-ResourceFactorygetInstancePseudo-factory.html for deprecation)