### PR TITLE
Fix stat records clearing cache of the wrong page (#69)

### DIFF
--- a/Classes/Controller/CookieController.php
+++ b/Classes/Controller/CookieController.php
@@ -77,7 +77,6 @@ class CookieController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
         else $newStat->setCookieconfig('custom');
         $newStat->setSeite($GLOBALS["TSFE"]->id);
  
-        $newStat->setPid($GLOBALS['TSFE']->rootLine[0]['uid']);
         $cookies0 = $this->cookieRepository->findByKategorie(0);
         $this->statRepository->add($newStat);
          //\TYPO3\CMS\Extbase\Utility\DebuggerUtility::var_dump($newStat);


### PR DESCRIPTION
Fixes #69 by letting Extbase set the correct pid of a new stat record.