### PR TITLE
Sets fallback value for tt_content uid in CookieController

### DIFF
--- a/Classes/Controller/CookieController.php
+++ b/Classes/Controller/CookieController.php
@@ -220,8 +220,8 @@ class CookieController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
         $direct = $this->settings['direct'] ?? null;
 
         $currentContentObject = $this->request->getAttribute('currentContentObject');
-        // ID of current tt_content record
-        $uid = $currentContentObject->data['uid'];
+        // ID of current tt_content record, if available 
+        $uid = $currentContentObject->data['uid'] ?? 0;
        
         /** @var FileReference[] $fileObjects */
         $fileObjects = $this->fileRepository->findByRelation('tt_content', 'settings.bild', $uid );


### PR DESCRIPTION
Sets 0 as fallback value for tt_content uid if record is not included via DB table tt_content

addresses issue #91