### PR TITLE
Adds fallback blocker text if respective array key is not set

### DIFF
--- a/Classes/Controller/CookieController.php
+++ b/Classes/Controller/CookieController.php
@@ -253,7 +253,7 @@ class CookieController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
         }
 
         $mycookie = $this->cookieRepository->findByUid($showcookie);
-        $this->view->assign('cookietext', $this->settings['text']);
+        $this->view->assign('cookietext', $this->settings['text'] ?? '');
         $this->view->assign('content1', $content1);
         $this->view->assign('active', $active);
         $this->view->assign('uid', $uid);


### PR DESCRIPTION
Prevents an error if a script included via TypoScript does not contain the array key "text", e.g. when such a text is not needed

Addresses #96